### PR TITLE
check that iis version is valid format

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,17 +1,21 @@
 # iis_version.rb
 Facter.add("iis_version") do
- confine :kernel => :windows
+  confine :kernel => :windows
   setcode do
     begin
       psexec = if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")
                  "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
                elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
-                "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
+                 "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
                else
-                'powershell.exe'
+                 'powershell.exe'
                end
 
       iis_ver = %x{#{psexec} -ExecutionPolicy ByPass -Command "(Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\InetStp\\ -Name VersionString).VersionString.SubString(8,3)"}
+      if iis_ver !~ /\d\.\d/
+        Facter.debug("Invalid iis_version")
+        iis_ver = nil
+      end
     rescue
       iis_ver = ""
     end

--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -12,7 +12,7 @@ Facter.add("iis_version") do
                end
 
       iis_ver = %x{#{psexec} -ExecutionPolicy ByPass -Command "(Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\InetStp\\ -Name VersionString).VersionString.SubString(8,3)"}
-      if iis_ver !~ /\d\.\d/
+      if iis_ver !~ /\d+\.\d+/
         Facter.debug("Invalid iis_version")
         iis_ver = nil
       end


### PR DESCRIPTION
I have had some issues where this fact failed on servers that don't have IIS installed on them.
So in case you use plugin sync in your environment this messes up the iis_version fact.
adding a check for a valid version solves this.