### PR TITLE
Alternative way of doing the iis_version fact

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,4 +1,4 @@
-Facter.add(:iis_version) do
+Facter.add(:iis_version4) do
   confine :kernel => :windows
   setcode do
 	version = nil
@@ -6,7 +6,7 @@ Facter.add(:iis_version) do
 	begin
 	Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Microsoft\InetStp') do |reg|
 	version = reg['VersionString']
-	 version = version[8,3]
+	 version = version[8..-1]
 	end
 rescue Win32::Registry::Error
 end

--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,20 +1,15 @@
-# iis_version.rb
-Facter.add("iis_version") do
- confine :kernel => :windows
+Facter.add(:iis_version) do
+  confine :kernel => :windows
   setcode do
-    begin
-      psexec = if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")
-                 "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
-               elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
-                "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
-               else
-                'powershell.exe'
-               end
-      iis_ver = %x{#{psexec} -ExecutionPolicy ByPass -Command "$regkey = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\InetStp\\ -Name VersionString -ea silentlycontinue;if ($regkey) {$regkey.VersionString.SubString(8,3)}"}
-    rescue
-      iis_ver = ""
-    end
-
-    iis_ver
-  end
+	version = nil
+	require 'win32/registry'
+	begin
+	Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Microsoft\InetStp') do |reg|
+	version = reg['VersionString']
+	 version = version[8,3]
+	end
+rescue Win32::Registry::Error
+end
+version
+end
 end


### PR DESCRIPTION
Hi,
Both me an my puppet master guy was not totally read up on the puppet-iis module so not knowing there was a fact included in the module for checking the version of IIS I kind of made my own, which of course led in to a minor war with your fact when pluginsync changes iis_version.rb back and forth.
Anyway I used ruby to check my iis version, which I think might be an good alternative to your wrapped powershell command, especially as your script returns a value (empty string) when there is no iis installed, where as mine returns nothing so the fact will only be present on systems having iis installed. I think that is a pretty way of doing it and thought I'd share it with you. Hopefully you like it aotherwise just discard it ;-).